### PR TITLE
respect Form.__init__() signature

### DIFF
--- a/bookmark/__init__.py
+++ b/bookmark/__init__.py
@@ -4,7 +4,7 @@ Bookmark flask app
 from flask import Flask
 
 from flaskext.login import LoginManager
-from flaskext.debugtoolbar import DebugToolbarExtension
+#from flaskext.debugtoolbar import DebugToolbarExtension
 
 
 from bookmark import settings

--- a/bookmark/blueprint/api/__init__.py
+++ b/bookmark/blueprint/api/__init__.py
@@ -51,7 +51,7 @@ def bookmarks(tags=None):
 
 @b.route('/bookmarks/', methods=['POST', ])
 def add_bookmark():
-    form = BookmarkForm(create=True, json=request.json)
+    form = BookmarkForm(request.json, create=True)
     ret = None
     if form.validate_on_submit():
         # register form

--- a/bookmark/blueprint/api/form/__init__.py
+++ b/bookmark/blueprint/api/form/__init__.py
@@ -18,12 +18,11 @@ class BookmarkForm(Form):
     tags = TextField(u'Tags')
     submit = SubmitField(u'Add')
 
-    def __init__(self, create, json=None, *args, **kwargs):
-        if json is not None:
-            dico = MultiDict(json.items())
-            kwargs['formdata'] = dico
-        Form.__init__(self, *args, **kwargs)
-        self.create = create
+    def __init__(self, formdata=None, *args, **kwargs):
+        if formdata is not None:
+            formdata = MultiDict(formdata.items())
+        self.create = kwargs.get('create', False)
+        super(BookmarkForm, self).__init__(formdata, *args, **kwargs)
 
     def validate(self):
         rv = Form.validate(self)

--- a/bookmark/blueprint/web/__init__.py
+++ b/bookmark/blueprint/web/__init__.py
@@ -8,5 +8,5 @@ b = Blueprint('web', __name__)
 
 @b.route('/', methods=['GET', ])
 def index():
-    form = BookmarkForm(True)
+    form = BookmarkForm(create=True)
     return render_template('index.html', form=form)


### PR DESCRIPTION
This change keeps the "create" argument without modifying the parent class signature
