### PR TITLE
minor changes

### DIFF
--- a/bookmark/blueprint/api/__init__.py
+++ b/bookmark/blueprint/api/__init__.py
@@ -73,13 +73,8 @@ def tagcloud(tags=None):
             pfilter=True), query_list)
         filters = map(lambda x: x.id, query_list)
 
-    tagcloud = get_tagcloud(filters)
-    filter_list = []
-    for (t, count) in tagcloud:
-        tag = ItemTag(t.id, t.name, count)
-        filter_list.append(tag)
-
-    tags_list = map(lambda x: x.json(), filter_list)
+    cloud = get_tagcloud(filters)
+    tags_list = [ItemTag(t.id, t.name, count).json() for t, count in cloud]
     process_tag_count(tags_list, max_percent=30, min_percent=11)
     tags_list = {"tags": [x.json() for x in filters_tags] + tags_list}
 

--- a/bookmark/blueprint/api/form/__init__.py
+++ b/bookmark/blueprint/api/form/__init__.py
@@ -9,7 +9,14 @@ from bookmark.blueprint.api.item.Bookmark import ItemBookmark
 from werkzeug.datastructures import MultiDict
 
 
-class BookmarkForm(Form):
+class AjaxForm(Form):
+    def __init__(self, formdata=None, *args, **kwargs):
+        if formdata is not None:
+            formdata = MultiDict(formdata.items())
+        super(AjaxForm, self).__init__(formdata, *args, **kwargs)
+
+
+class BookmarkForm(AjaxForm):
     id = HiddenField(u'Id')
     link = URLField(u'Link', validators=[validators.required(),
         validators.url(), ])
@@ -19,8 +26,6 @@ class BookmarkForm(Form):
     submit = SubmitField(u'Add')
 
     def __init__(self, formdata=None, *args, **kwargs):
-        if formdata is not None:
-            formdata = MultiDict(formdata.items())
         self.create = kwargs.get('create', False)
         super(BookmarkForm, self).__init__(formdata, *args, **kwargs)
 


### PR DESCRIPTION
create a more generic/reusable AjaxForm
use a list comprehension instead of forloop->map
rename variable to prevent conflicts with function name
